### PR TITLE
Change to if statements instead `switch` statements when parsing toml file. 

### DIFF
--- a/prometheus-pusher.go
+++ b/prometheus-pusher.go
@@ -48,6 +48,11 @@ func main() {
 		go getAndPush(metric.Name, metric.URL, pusher.PushGatewayURL, hostname, dummy)
 	}
 	for _ = range time.Tick(pusher.PushInterval) {
+		pusher, err := parseConfig(*path)
+		if err != nil {
+			logger.Error("Error parsing configuration", err.Error())
+		}
+
 		for _, metric := range pusher.Metrics {
 			go getAndPush(metric.Name, metric.URL, pusher.PushGatewayURL, hostname, dummy)
 		}
@@ -171,7 +176,7 @@ func getMetrics(metricURL string) []byte {
 
 func pushMetrics(metricName string, pushgatewayURL string, instance string, metrics []byte, dummy *bool) {
 	postURL := fmt.Sprintf("%s/metrics/job/%s/instance/%s", pushgatewayURL, metricName, instance)
-	if (*dummy) {
+	if *dummy {
 		fmt.Println(string(metrics))
 	} else {
 		logger.Info("Pushing Node exporter metrics", "endpoint", postURL)

--- a/prometheus-pusher.go
+++ b/prometheus-pusher.go
@@ -103,16 +103,13 @@ func parseConfig(path string) (pusherConfig, error) {
 
 			if metric == "config" {
 
-				switch {
-				case tomlFile["config.pushgateway_url"].IsValue():
+				if tomlFile["config.pushgateway_url"].IsValue() {
 					conf.PushGatewayURL = tomlFile["config.pushgateway_url"].String()
+				}
 
-				case tomlFile["config.push_interval"].IsValue():
+				if tomlFile["config.push_interval"].IsValue() {
 					interval := tomlFile["config.push_interval"].Int()
 					conf.PushInterval = time.Duration(interval) * time.Second
-
-				default:
-					logger.Warn("Unknown configuration field", "config_section", metric)
 				}
 
 			} else {
@@ -122,23 +119,22 @@ func parseConfig(path string) (pusherConfig, error) {
 				path := "/metrics"
 				scheme := "http"
 
-				switch {
-				case tomlFile[metric+".host"].IsValue():
+				if tomlFile[metric+".host"].IsValue() {
 					host = tomlFile[metric+".host"].String()
+				}
 
-				case tomlFile[metric+".path"].IsValue():
+				if tomlFile[metric+".path"].IsValue() {
 					path = tomlFile[metric+".path"].String()
+				}
 
-				case tomlFile[metric+".ssl"].IsValue():
+				if tomlFile[metric+".ssl"].IsValue() {
 					if tomlFile[metric+".ssl"].Boolean() {
 						scheme = "https"
 					}
+				}
 
-				case tomlFile[metric+".port"].IsValue():
+				if tomlFile[metric+".port"].IsValue() {
 					port = tomlFile[metric+".port"].Integer()
-
-				default:
-					logger.Warn("Unknown configuration field", "config_section", metric)
 				}
 
 				if port == 0 {


### PR DESCRIPTION
If I'm right,the  `switch` statement is not good when using to check & get  TOML config data . I met `Port is not defined` error message (My config file has `port = 9100`). Because If a first `case` is ok, the control flow in Go will  break in `switch` block.
I changed it  `if` statements. 

Thanks,
MS
