### PR TITLE
Fix crash caused by bug in sockrus, cut down log messages

### DIFF
--- a/vendor/github.com/ShowMax/sockrus/hook.go
+++ b/vendor/github.com/ShowMax/sockrus/hook.go
@@ -1,7 +1,6 @@
 package sockrus
 
 import (
-	"fmt"
 	"net"
 	"time"
 
@@ -12,10 +11,8 @@ import (
 // Hook represents a connection to a socket
 type Hook struct {
 	formatter logrus_logstash.LogstashFormatter
-	conn      net.Conn
 	protocol  string
 	address   string
-	mute      bool
 }
 
 // NewHook establish a socket connection.
@@ -30,67 +27,31 @@ func NewHook(protocol, address string) (*Hook, error) {
 		TimestampFormat: time.RFC3339Nano,
 	}
 	return &Hook{
-		conn:      nil,
 		protocol:  protocol,
 		address:   address,
 		formatter: logstashFormatter,
-		mute:      false,
 	}, nil
 }
 
 // Fire send log to the defined socket
 func (h *Hook) Fire(entry *logrus.Entry) error {
 	var err error
-	if h.conn == nil {
-		err = h.dialSock()
-		if err != nil && h.mute == false {
-			h.mute = true
-			retErr := fmt.Errorf("Failed to dial. All further errors will be muted: %v", err)
-			return retErr
-		} else if err != nil && h.mute == true {
-			return nil
-		}
-	}
 	dataBytes, err := h.formatter.Format(entry)
 	if err != nil {
 		return err
 	}
-	if _, err = h.conn.Write(dataBytes); err != nil {
-		_ = h.closeSock() // #nosec
-		if h.mute == false {
-			h.mute = true
-			retErr := fmt.Errorf("Failed to write data. All further errors will be muted: %v", err)
-			return retErr
-		} else {
-			return nil
-		}
+
+	conn, err := net.Dial(h.protocol, h.address)
+	if err != nil {
+		return nil
 	}
+	defer conn.Close()
+
+	_, _ = conn.Write(dataBytes) // #nosec
 	return nil
 }
 
 // Levels return an array of handled logging levels
 func (h *Hook) Levels() []logrus.Level {
 	return logrus.AllLevels
-}
-
-// closeSock tries to close connection to Unix socket
-func (h *Hook) closeSock() error {
-	if h.conn == nil {
-		return nil
-	}
-	err := h.conn.Close()
-	h.conn = nil
-	return err
-}
-
-// dialSock tries to connect to Unix socket
-func (h *Hook) dialSock() error {
-	conn, err := net.Dial(h.protocol, h.address)
-	if err != nil {
-		h.conn = nil
-		return err
-	}
-	h.conn = conn
-	h.mute = false
-	return nil
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,10 +9,10 @@
 			"revisionTime": "2016-04-14T10:53:56Z"
 		},
 		{
-			"checksumSHA1": "eHW81NSOL2Jr0BX1W5DA4DfAfI4=",
+			"checksumSHA1": "uoB6KP1KNhKHvALBxGOJAkMqp00=",
 			"path": "github.com/ShowMax/sockrus",
-			"revision": "337906565a8defc77fef3d43ac56c884a19237e1",
-			"revisionTime": "2016-10-26T13:43:25Z"
+			"revision": "afe97c67efe588ba64e5c7bf0ee6f6991bc6b98f",
+			"revisionTime": "2016-12-17T07:28:22Z"
 		},
 		{
 			"checksumSHA1": "h5Q1o+kA7VMAR5QpBzVJZbBEgC0=",


### PR DESCRIPTION
* Fixes crash caused by bug in sockrus
* Cuts down logging to errors as it seems irrelevant to log each and every step of the application, eg. collect and push metrics
* Remove the need of logger from parseConfig() and getConfigFiles()