### PR TITLE
Allow configure fetching values from ENV to labels from multiple places

### DIFF
--- a/config.go
+++ b/config.go
@@ -106,10 +106,11 @@ func parseConfig(data []byte) (*pusherConfig, error) {
 	if envLabelsSet {
 		envLabels := make([][]byte, 0)
 		for _, label := range envLabelLabels {
-			val := os.Getenv(label.(string))
+		        strLabel := label.(string)
+			val := os.Getenv(strLabel)
 			if len(val) != 0 {
-				envLabels = append(envLabels, []byte(fmt.Sprintf(`%s="%s"`, strings.ToLower(label.(string)), val)))
-				logger.Debugf("Got additional ENV label %s with value %s", strings.ToLower(label.(string)), val)
+				envLabels = append(envLabels, []byte(fmt.Sprintf(`%s="%s"`, strings.ToLower(strLabel)), val)))
+				logger.Debugf("Got additional ENV label %s with value %s", strings.ToLower(strLabel), val)
 
 			}
 		}

--- a/config.go
+++ b/config.go
@@ -92,17 +92,25 @@ func parseConfig(data []byte) (*pusherConfig, error) {
 	}
 
 	p.envLabels = make([]byte, 0)
-	if t.Has("config.env_labels") {
-		envLabelLabels := t.Get("config.env_labels").([]interface{})
+	envLabelLabels := make([]interface{}, 0)
+	envLabelsSet := false
+	if t.Has("default_env_labels") && t.Has("default_env_labels.env_labels") {
+		envLabelLabels = append(envLabelLabels, t.Get("default_env_labels.env_labels").([]interface{})...)
+		envLabelsSet = true
+	}
+	if t.Has("service_env_labels") && t.Has("service_env_labels.env_labels") {
+		envLabelLabels = append(envLabelLabels, t.Get("service_env_labels.env_labels").([]interface{})...)
+		envLabelsSet = true
+	}
+
+	if envLabelsSet {
 		envLabels := make([][]byte, 0)
 		for _, label := range envLabelLabels {
-			strLabel := label.(string)
-			val := os.Getenv(strLabel)
+			val := os.Getenv(label.(string))
 			if len(val) != 0 {
-				envLabels = append(envLabels, []byte(fmt.Sprintf(`%s="%s"`, strings.ToLower(strLabel), val)))
-				logger.Debugf("Added %s=%s label from environment", strLabel, val)
-			} else {
-				logger.Warnf("Tried to fetch %s from environment but it's missing", strLabel)
+				envLabels = append(envLabels, []byte(fmt.Sprintf(`%s="%s"`, strings.ToLower(label.(string)), val)))
+				logger.Debugf("Got additional ENV label %s with value %s", strings.ToLower(label.(string)), val)
+
 			}
 		}
 		p.envLabels = bytes.Join(envLabels, []byte(","))
@@ -127,7 +135,7 @@ func parseConfig(data []byte) (*pusherConfig, error) {
 	}
 
 	for _, resName := range t.Keys() {
-		if resName == "config" {
+		if resName == "config" || resName == "default_env_labels" || resName == "service_env_labels" {
 			continue
 		}
 

--- a/test/config
+++ b/test/config
@@ -1,5 +1,4 @@
 [config]
-env_labels = ["FOO"]
 pushgateway_url = "http://%s:9091/metrics"
 route_map = "test/routes"
 default_route = "test0,test-bck"
@@ -12,3 +11,9 @@ port = 9091
 pushgateway_url = "http://test-static:9091/metrics"
 host = "test-remote"
 port = 9091
+
+[default_env_labels]
+env_labels = ["FOO", "BAR"]
+
+[service_env_labels]
+env_labels = ["FOOBAR"]


### PR DESCRIPTION
This way we will be able to define "global" per all instances settings via `default_env_labels` and per service labels via `service_env_labels`